### PR TITLE
Rebase the fiat-ed25519 backend on release 1.0.0-pre3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,12 @@ exclude = [ ".gitignore", "TESTVECTORS", "res/*" ]
 [badges]
 travis-ci = { repository = "dalek-cryptography/ed25519-dalek", branch = "master"}
 
+[dependencies.curve25519-dalek]
+git = "https://github.com/calibra/curve25519-dalek.git"
+branch = "fiat2"
+version = "2"
+default-features = false
+
 [package.metadata.docs.rs]
 # Disabled for now since this is borked; tracking https://github.com/rust-lang/docs.rs/issues/302
 # rustdoc-args = ["--html-in-header", ".cargo/registry/src/github.com-1ecc6299db9ec823/curve25519-dalek-0.13.2/rustdoc-include-katex-header.html"]
@@ -23,7 +29,6 @@ features = ["nightly", "batch"]
 
 [dependencies]
 clear_on_drop = { version = "0.2" }
-curve25519-dalek = { version = "2", default-features = false }
 merlin = { version = "1", default-features = false, optional = true, git = "https://github.com/isislovecruft/merlin", branch = "develop" }
 rand = { version = "0.7", default-features = false, optional = true }
 rand_core = { version = "0.5", default-features = false, optional = true }
@@ -54,6 +59,7 @@ batch_deterministic = ["merlin", "rand", "rand_core"]
 asm = ["sha2/asm"]
 # This features turns off stricter checking for scalar malleability in signatures
 legacy_compatibility = []
+fiat_u64_backend = ["curve25519-dalek/fiat_u64_backend"]
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
 simd_backend = ["curve25519-dalek/simd_backend"]


### PR DESCRIPTION
I'll also submit a PR to switch the libra dependency pointers from fiat to fiat2, once the updates to branch fiat2 of:
- `calibra/curve25519-dalek`
- `calibra/x25519-dalek`
- `calibra/ed25519-dalek`
are all in place and merged.

A variant of this which points to my own fork, suitable for testing, is at:
https://github.com/huitseeker/ed25519-dalek/tree/fiat2-test