### PR TITLE
version mismatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ features = ["nightly", "batch"]
 
 [dependencies]
 clear_on_drop = { version = "0.2" }
-merlin = { version = "1", default-features = false, optional = true, git = "https://github.com/isislovecruft/merlin", branch = "develop" }
+merlin = { version = "2.0.0", default-features = false, optional = true, git = "https://github.com/isislovecruft/merlin", branch = "develop" }
 rand = { version = "0.7", default-features = false, optional = true }
 rand_core = { version = "0.5", default-features = false, optional = true }
 serde = { version = "1.0", optional = true }


### PR DESCRIPTION
Either merge this pr or https://github.com/libra/libra/pull/5043 to make libra use fiat3.

The pull can be used a proof the changes are sufficient.