### PR TITLE
Bump 1.0.0 pre.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [ ".gitignore", "TESTVECTORS", "res/*" ]
 travis-ci = { repository = "dalek-cryptography/ed25519-dalek", branch = "master"}
 
 [dependencies.curve25519-dalek]
-git = "https://github.com/calibra/curve25519-dalek.git"
+git = "https://github.com/novifinancial/curve25519-dalek.git"
 branch = "fiat2"
 version = "2"
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,18 @@ exclude = [ ".gitignore", "TESTVECTORS", "res/*" ]
 [badges]
 travis-ci = { repository = "dalek-cryptography/ed25519-dalek", branch = "master"}
 
+[dependencies.curve25519-dalek]
+git = "https://github.com/calibra/curve25519-dalek.git"
+branch = "fiat2"
+version = "2"
+default-features = false
+
 [package.metadata.docs.rs]
 # Disabled for now since this is borked; tracking https://github.com/rust-lang/docs.rs/issues/302
 # rustdoc-args = ["--html-in-header", ".cargo/registry/src/github.com-1ecc6299db9ec823/curve25519-dalek-0.13.2/rustdoc-include-katex-header.html"]
 features = ["nightly", "batch"]
 
 [dependencies]
-curve25519-dalek = { version = "2", default-features = false }
 ed25519 = { version = "1", default-features = false }
 merlin = { version = "2", default-features = false, optional = true }
 rand = { version = "0.7", default-features = false, optional = true }
@@ -58,6 +63,7 @@ batch_deterministic = ["merlin", "rand", "rand_core"]
 asm = ["sha2/asm"]
 # This features turns off stricter checking for scalar malleability in signatures
 legacy_compatibility = []
+fiat_u64_backend = ["curve25519-dalek/fiat_u64_backend"]
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
 simd_backend = ["curve25519-dalek/simd_backend"]


### PR DESCRIPTION
This rebases the construction of the fiat backend on top of ed25519-dalek 1.0.0-pre.4

~~Do not merge, as this comes with downstream consequences:~~
~~https://github.com/libra/libra/pull/5178~~

~~I'll re-issue on a different branch.~~ Edit: re-issued