### PR TITLE
Pick up the latest curve25519-dalek

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "dalek-cryptography/ed25519-dalek", branch = "master"
 
 [dependencies.curve25519-dalek]
 git = "https://github.com/novifinancial/curve25519-dalek.git"
-branch = "fiat3"
+branch = "fiat4"
 version = "3"
 default-features = false
 


### PR DESCRIPTION
and the fiat-crypto backend.

The current PR is opened against fiat5, which is the version automatically picked up by diem. To ensure we have the ability to have rollbacks, it should instead be merged into a **new** branch that we will then point diem towards (preserving the fiat5 pointer in case we need a rollback). To create this new branch (fiat6), I suggest:
```
cd checkout/of/ed25519-dalek
NOVI_FORK=$(git remote -v| grep 'github\.com/novifinancial/ed25519-dalek'| awk '{print $1}'|uniq)
git checkout fiat5 && git reset --hard $NOVI_FORK/fiat5
git checkout -b fiat6
git push -u $NOVI_FORK fiat6
```

Then we can retarget this present PR to the newly created fiat5 (toggle the target at the top of the PR's web page) and merge.