### PR TITLE
Update to compile with rust > 1.48

### DIFF
--- a/src/aggregated_signature.rs
+++ b/src/aggregated_signature.rs
@@ -280,7 +280,7 @@ impl QuasiAggregatedSignature {
                 .iter()
                 .map(|sig| sig.s)
                 .rev()
-                .fold_first(|acc, sig_scalar| (acc * e + sig_scalar))
+                .reduce(|acc, sig_scalar| (acc * e + sig_scalar))
                 .unwrap();
             let mut h = init_hash.clone(); // ha is already contained in h
             h.update(j.to_le_bytes());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,6 @@
 #![deny(missing_docs)] // refuse to compile if documentation is missing
 #![cfg(not(test))]
 #![forbid(unsafe_code)]
-#![feature(iterator_fold_self)]
 
 #[cfg(any(feature = "std", test))]
 #[macro_use]


### PR DESCRIPTION
The fold_first method has been changed to reduce in rust >1.48.
This change allows "cargo build" to work with the latest rust version.